### PR TITLE
chore: updated readme, outscoping the comments from the e.g., commands

### DIFF
--- a/vyuh_cli/README.md
+++ b/vyuh_cli/README.md
@@ -71,8 +71,9 @@ Run "vyuh help" to see global options.
 
 `vyuh create project <project-name>`
 
+###### Create a new Vyuh project named super_app
+
 ```sh
-# Create a new Vyuh project named super_app
 
 vyuh create project super_app
 
@@ -97,8 +98,8 @@ Usage: vyuh create project <project-name> [arguments]
 
 `vyuh create feature <feature-name>`
 
+###### Create a new Vyuh feature named super_feature
 ```sh
-# Create a new Vyuh feature named super_feature
 vyuh create feature super_feature
 ```
 
@@ -114,8 +115,8 @@ Usage: vyuh create feature <feature-name> [arguments]
 
 `vyuh create schema <feature-name>`
 
+###### Create a new Vyuh feature CMS schema named super_feature_schema
 ```sh
-# Create a new Vyuh feature CMS schema named super_feature_schema
 vyuh create schema super_schema
 ```
 


### PR DESCRIPTION
Since the commands are terminal-based, including comments in the copy-paste block can make it inconvenient for users to edit the copied message before pasting it into the terminal or command prompt.